### PR TITLE
Add basic PDF processor test

### DIFF
--- a/anki_builder/requirements.txt
+++ b/anki_builder/requirements.txt
@@ -7,3 +7,4 @@ python-dotenv==1.0.1
 numpy==1.24.4
 tenacity==8.3.0
 tiktoken==0.7.0
+pytest>=7.0

--- a/tests/test_pdf_processor.py
+++ b/tests/test_pdf_processor.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+from anki_builder.src.services.pdf_processor import PDFPreprocessor
+
+
+def test_pdf_processor_extract_and_chunk():
+    pytest.importorskip("fitz")
+    pytest.importorskip("tiktoken")
+
+    pdf_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "anki_builder", "pdfs", "SelfRAG.pdf"))
+    preprocessor = PDFPreprocessor(pdf_path)
+    preprocessor.extract_text()
+    preprocessor.chunk_text(max_tokens=100)
+
+    assert preprocessor.text_content
+    assert preprocessor.chunks
+    assert preprocessor.total_tokens > 0


### PR DESCRIPTION
## Summary
- add a pytest covering `PDFPreprocessor`
- include pytest in Python requirements

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*